### PR TITLE
dependency upgrade and configuration change

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2016 timeoutdigital
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ kamon {
     batch-size = 20
 
     # only logs metrics to file without shipping out to Cloudwatch
-    log-metrics-only = false
+    disable-send = false
 
     # how many threads will be assigned to the pool that does the shipment of metrics
     async-threads = 5

--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ kamon {
     # batch size of data when send to Cloudwatch    
     batch-size = 20
 
-    # only logs metrics to file without shipping out to Cloudwatch
-    disable-send = false
+    # only logs metrics to file without shipping out to Cloudwatch if it is false
+    send-metrics = true
 
     # how many threads will be assigned to the pool that does the shipment of metrics
     async-threads = 5
@@ -75,3 +75,6 @@ kamon {
 # AWS Cloudwatch Example
 - log on to Cloudwatch, the metrics will be appearing on 'Custom namespaces' section under "Metrics" menu, i.e.:
 ![alt text](https://github.com/timeoutdigital/kamon-cloudwatch/blob/master/doc/cloundwatch-metrics.png "what has showed up in Cloudwatch")
+
+# License
+- [MIT](https://github.com/timeoutdigital/kamon-cloudwatch/blob/master/LICENSE "MIT")

--- a/build.sbt
+++ b/build.sbt
@@ -1,16 +1,16 @@
 name := "kamon-cloudwatch"
 
-version := "0.0.1"
+version := "0.0.2-SNAPSHOT"
 
 organization := "com.timeout"
 
 releaseCrossBuild := true
 
-scalaVersion := "2.11.8"
+scalaVersion := "2.11.11"
 
 licenses += ("MIT", url("https://opensource.org/licenses/MIT"))
 
-crossScalaVersions := Seq("2.11.8", "2.12.2")
+crossScalaVersions := Seq("2.11.11", "2.12.2")
 
 credentials += Credentials(Path.userHome / ".bintray" / ".credentials")
 

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -13,7 +13,7 @@ kamon {
     batch-size = 20
 
     # only logs metrics to file without shipping out to Cloudwatch
-    log-metrics-only = false
+    disable-send = false
 
     # how many threads will be assigned to the pool that does the shipment of metrics
     async-threads = 5

--- a/src/main/resources/reference.conf
+++ b/src/main/resources/reference.conf
@@ -12,8 +12,8 @@ kamon {
     # batch size of data when send to Cloudwatch
     batch-size = 20
 
-    # only logs metrics to file without shipping out to Cloudwatch
-    disable-send = false
+    # only logs metrics to file without shipping out to Cloudwatch if it is false
+    send-metrics = true
 
     # how many threads will be assigned to the pool that does the shipment of metrics
     async-threads = 5

--- a/src/main/scala/com/timeout/kamon/cloudwatch/KamonCloudWatchExtension.scala
+++ b/src/main/scala/com/timeout/kamon/cloudwatch/KamonCloudWatchExtension.scala
@@ -12,8 +12,8 @@ import scala.concurrent.ExecutionContextExecutor
   * Register pattern subscriptions with underlying subscriber actor
   */
 class KamonCloudWatchExtension(system: ExtendedActorSystem) extends Kamon.Extension {
-  implicit val ec: ExecutionContextExecutor = system.dispatcher
-  protected val log = Logging(system, classOf[KamonCloudWatchExtension])
+  private implicit val ec: ExecutionContextExecutor = system.dispatcher
+  private val log = Logging(system, classOf[KamonCloudWatchExtension])
   log.info("Starting the Kamon CloudWatch extension")
 
   val shipper: ActorRef = system.actorOf(MetricsShipper.props, "cloudwatch-metrics-shipper")

--- a/src/main/scala/com/timeout/kamon/cloudwatch/KamonSettings.scala
+++ b/src/main/scala/com/timeout/kamon/cloudwatch/KamonSettings.scala
@@ -16,6 +16,6 @@ object KamonSettings {
   private[cloudwatch] val nameSpace = cloudWatchConfig.getString("namespace")
   private[cloudwatch] val region = cloudWatchConfig.getString("region")
   private[cloudwatch] val batchSize = cloudWatchConfig.getInt("batch-size")
-  private[cloudwatch] val logOnly = cloudWatchConfig.getBoolean("log-metrics-only")
+  private[cloudwatch] val disabled= cloudWatchConfig.getBoolean("disable-send")
   private[cloudwatch] val numThreads = cloudWatchConfig.getInt("async-threads")
 }

--- a/src/main/scala/com/timeout/kamon/cloudwatch/KamonSettings.scala
+++ b/src/main/scala/com/timeout/kamon/cloudwatch/KamonSettings.scala
@@ -16,6 +16,6 @@ object KamonSettings {
   private[cloudwatch] val nameSpace = cloudWatchConfig.getString("namespace")
   private[cloudwatch] val region = cloudWatchConfig.getString("region")
   private[cloudwatch] val batchSize = cloudWatchConfig.getInt("batch-size")
-  private[cloudwatch] val disabled= cloudWatchConfig.getBoolean("disable-send")
+  private[cloudwatch] val sendMetrics= cloudWatchConfig.getBoolean("send-metrics")
   private[cloudwatch] val numThreads = cloudWatchConfig.getInt("async-threads")
 }

--- a/src/main/scala/com/timeout/kamon/cloudwatch/MetricsLogger.scala
+++ b/src/main/scala/com/timeout/kamon/cloudwatch/MetricsLogger.scala
@@ -21,8 +21,8 @@ class MetricsLogger(shipper: ActorRef) extends Actor with ActorLogging {
     case tick: TickMetricSnapshot =>
       data(tick).sliding(batchSize, batchSize).foreach { data =>
         // allow a latch to only log the metrics without pushing out onto Cloudwatch
-        data.foreach(d => log.debug(d.toString))
-        if (!KamonSettings.logOnly) shipper ! ShipMetrics(data)
+        if (KamonSettings.disabled) log.info(data.mkString(", ")) //TODO print pretty json
+        else shipper ! ShipMetrics(data)
       }
 
     case msg => log.warning(s"Unsupported message $msg received in MetricsLogger")

--- a/src/main/scala/com/timeout/kamon/cloudwatch/MetricsLogger.scala
+++ b/src/main/scala/com/timeout/kamon/cloudwatch/MetricsLogger.scala
@@ -21,7 +21,7 @@ class MetricsLogger(shipper: ActorRef) extends Actor with ActorLogging {
     case tick: TickMetricSnapshot =>
       data(tick).sliding(batchSize, batchSize).foreach { data =>
         // allow a latch to only log the metrics without pushing out onto Cloudwatch
-        if (KamonSettings.disabled) log.info(data.mkString(", ")) //TODO print pretty json
+        if (!KamonSettings.sendMetrics) log.debug(data.mkString(", ")) //TODO print pretty json
         else shipper ! ShipMetrics(data)
       }
 


### PR DESCRIPTION
- dependency version upgrade
- configuration change: 'log-metrics-only' property field is changed to 'disable-send', which will stop sending to Cloudwatch, but it will log@info level instead